### PR TITLE
docs(github pages): fixed GitHub pages asset path directory resolution

### DIFF
--- a/pages/.vitepress/config.mts
+++ b/pages/.vitepress/config.mts
@@ -3,26 +3,18 @@ import { defineConfig } from 'vitepress'
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Generative AI Newsletter App",
+  base: "/generative-ai-newsletter-app/",
   description: "The Generative AI Newsletter Application sample is a ready-to-use serverless solution designed to allow users to create rich newsletters automatically with content summaries that are AI-generated.",
   themeConfig: {
-    // https://vitepress.dev/reference/default-theme-config
+    search: {
+      provider: 'local'
+    },
     nav: [
       { text: 'Home', link: '/' },
       { text: 'About', link: '/about'},
       { text: 'User Guide', link: '/user-guide' },
       { text: 'Deployment Guide', link: '/deployment' },
     ],
-
-    sidebar: [
-      // {
-      //   text: 'Examples',
-      //   items: [
-      //     { text: 'Markdown Examples', link: '/markdown-examples' },
-      //     { text: 'Runtime API Examples', link: '/api-examples' }
-      //   ]
-      // }
-    ],
-
     socialLinks: [
       { icon: 'github', link: 'https://github.com/aws-samples/generative-ai-newsletter-app' }
     ]


### PR DESCRIPTION
Resolves an issue where the GitHub Pages site was not resolving assets under the repo's path.