### PR TITLE
fix(authz): fixed bug causing list filter to show private items

### DIFF
--- a/lib/authorization/authorization-helper.ts
+++ b/lib/authorization/authorization-helper.ts
@@ -131,6 +131,31 @@ export const queryToResourceEntity = (query: string): string => {
   }
 }
 
+export const queryToResourcesEntity = (query: string): string => {
+  const action = queryToActionAuth(query)
+  const queries = schemaMap.__schema.types.find((type) => {
+    return type.name === 'Query' && type.kind === 'OBJECT'
+  })
+  if (queries === undefined || queries === null) {
+    throw new Error('Unable to locate Query type')
+  }
+  const queryFieldType = queries.fields?.find((field) => {
+    return field.name === action
+  })
+  if (queryFieldType !== undefined) {
+    const queryFieldTypeObject = schemaMap.__schema.types.find((type) => {
+      return type.name === queryFieldType.type.name
+    })
+    const itemObject = queryFieldTypeObject?.fields?.find((fieldItem) => {
+      return fieldItem.name === 'items'
+    })
+    if (itemObject !== undefined && itemObject.type.kind === 'LIST' && itemObject?.type?.ofType?.name !== undefined && itemObject?.type?.ofType?.name !== null) {
+      return itemObject.type.ofType?.name
+    }
+  }
+  throw new Error('Unable to locate resource Entity')
+}
+
 export const mutationToResourceEntity = (query: string): string => {
   const action = queryToActionAuth(query)
   const queries = schemaMap.__schema.types.find((type) => {

--- a/lib/authorization/index.list-filter-authorization.ts
+++ b/lib/authorization/index.list-filter-authorization.ts
@@ -12,7 +12,7 @@ import { MetricUnits, Metrics } from '@aws-lambda-powertools/metrics'
 import middy from '@middy/core'
 import { type Context } from 'aws-lambda'
 import { GetSchemaCommand, VerifiedPermissionsClient, type IsAuthorizedCommandInput, IsAuthorizedCommand, Decision } from '@aws-sdk/client-verifiedpermissions'
-import { getEntityItem, lowercaseFirstLetter, queryToActionAuth, queryToResourceEntity } from './authorization-helper'
+import { getEntityItem, lowercaseFirstLetter, queryToActionAuth, queryToResourcesEntity } from './authorization-helper'
 
 const SERVICE_NAME = 'list-filter-authorization'
 
@@ -83,7 +83,7 @@ const checkItemAuthorization = async (item: any, schema: Record<string, any>, us
       actionType: 'GenAINewsletter::Action'
     },
     resource: {
-      entityType: `GenAINewsletter::${queryToResourceEntity(queryString)}`,
+      entityType: `GenAINewsletter::${queryToResourcesEntity(queryString)}`,
       entityId: item.id
     },
     entities: {
@@ -102,7 +102,7 @@ const checkItemAuthorization = async (item: any, schema: Record<string, any>, us
             }
           }
         },
-        getEntityItem(schema, item.id as string, queryToResourceEntity(queryString), item as Record<string, any>, { logger })
+        getEntityItem(schema, item.id as string, queryToResourcesEntity(queryString), item as Record<string, any>, { logger })
       ]
     }
 


### PR DESCRIPTION
Fixed logic used to parse GraphQL schema to generate Authorization request to locate the item type that a collection of items is returning. It depends on the list of items to be an array called 'items'

fix #30


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
