### PR TITLE
fix(authz): fixed listPublications endpoint authorization error

### DIFF
--- a/lib/api/functions/pipeline/listPublications/index.ts
+++ b/lib/api/functions/pipeline/listPublications/index.ts
@@ -4,7 +4,7 @@ import {
   type DynamoDBQueryRequest
 } from '@aws-appsync/utils'
 import * as ddb from '@aws-appsync/utils/dynamodb'
-import { filterForDuplicatesById } from '../../resolver-helper'
+import { addAccountToItem, filterForDuplicatesById } from '../../resolver-helper'
 
 export function request (ctx: Context): DynamoDBQueryRequest {
   const { nextToken, limit = 250 } = ctx.args
@@ -51,16 +51,15 @@ export const response = (ctx: Context): any => {
           filePath = '/' + filePath
         }
       }
-
-      items.push({
+      let itemToPush = {
         newsletterId,
+        accountId,
         id: publicationId,
-        account: {
-          id: accountId
-        },
         createdAt,
         filePath
-      })
+      }
+      itemToPush = addAccountToItem(itemToPush)
+      items.push(itemToPush)
     }
   }
   let result = {

--- a/lib/authorization/cedarschema.json
+++ b/lib/authorization/cedarschema.json
@@ -2,6 +2,9 @@
   "GenAINewsletter": {
     "entityTypes": {
       "Publication": {
+        "memberOfTypes": [
+          "Newsletter"
+        ],
         "shape": {
           "type": "Record",
           "attributes": {
@@ -13,12 +16,14 @@
             "id": {
               "required": true,
               "type": "String"
+            },
+            "Account": {
+              "required": true,
+              "type": "Entity",
+              "name": "Account"
             }
           }
-        },
-        "memberOfTypes": [
-          "Newsletter"
-        ]
+        }
       },
       "Account": {
         "memberOfTypes": [],


### PR DESCRIPTION
The listPublications function was adding the accountId improperly, causing authz logic to not allow any publications to be viewed, even by the owner. Additionally, added the Account entity as a required attribute for Publication in the cedar schema

fix #79


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
